### PR TITLE
Improvement: Make slideshow demo work right away

### DIFF
--- a/examples/slideshow/index.css
+++ b/examples/slideshow/index.css
@@ -1,105 +1,21 @@
-.slide-show {
-  width: 100vw;
-  height: 100vh;
-  max-height: -webkit-fill-available;
-  overflow: hidden;
+body {
+  margin: 0;
 }
-.slide-show .preview {
+
+#app {
   width: 100%;
-  height: 100%;
+  height: 480px;
   display: flex;
-  overflow: hidden;
-  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
-.slide-show .preview .background {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  flex-grow: 1;
-  background-size: cover;
-  background-position: center;
-  animation-name: slide-show-image;
-  animation-duration: 6s;
-  animation-timing-function: linear;
-  overflow: hidden;
-}
-@keyframes slide-show-image-0 {
-  0% {
-    transform: scale(1, 1) translate(0, 0);
-    opacity: 100%;
-  }
-  80% {
-    opacity: 100%;
-  }
-  100% {
-    transform: scale(115%, 115%) translate(5%, 5%);
-    opacity: 0%;
-  }
-}
-@keyframes slide-show-image-1 {
-  0% {
-    transform: scale(1, 1) translate(0, 0);
-    opacity: 100%;
-  }
-  80% {
-    opacity: 100%;
-  }
-  100% {
-    transform: scale(115%, 115%) translate(1%, 5%);
-    opacity: 0%;
-  }
-}
-@keyframes slide-show-image-2 {
-  0% {
-    transform: scale(1, 1) translate(0, 0);
-    opacity: 100%;
-  }
-  80% {
-    opacity: 100%;
-  }
-  100% {
-    transform: scale(115%, 115%) translate(-5%, 5%);
-    opacity: 0%;
-  }
-}
-@keyframes slide-show-image-3 {
-  0% {
-    transform: scale(1, 1) translate(0, 0);
-    opacity: 100%;
-  }
-  80% {
-    opacity: 100%;
-  }
-  100% {
-    transform: scale(115%, 115%) translate(-1%, 5%);
-    opacity: 0%;
-  }
-}
-@keyframes slide-show-image-4 {
-  0% {
-    transform: scale(1, 1) translate(0, 0);
-    opacity: 100%;
-  }
-  80% {
-    opacity: 100%;
-  }
-  100% {
-    transform: scale(115%, 115%) translate(-5%, -5%);
-    opacity: 0%;
-  }
-}
-@keyframes slide-show-image-5 {
-  0% {
-    transform: scale(1, 1) translate(0, 0);
-    opacity: 100%;
-  }
-  80% {
-    opacity: 100%;
-  }
-  100% {
-    transform: scale(115%, 115%) translate(5%, -5%);
-    opacity: 0%;
-  }
+
+p {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1em;
+  font-weight: 600;
+  color: black;
+  text-align: left;
+  margin: 60px;
 }

--- a/examples/slideshow/index.html
+++ b/examples/slideshow/index.html
@@ -1,5 +1,33 @@
-<template id="SlideShow">
-  <div class="slide-show">
-    <div class="preview"></div>
-  </div>
-</template>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slideshow</title>
+  <link rel="stylesheet" href="./index.css">
+  <script src="../../template.js"></script>
+</head>
+<body>
+
+  <div id="app"></div>
+
+  <template id="SlideShow">
+    <link rel="stylesheet" href="slideshow.css">
+    <div class="slide-show">
+      <div class="preview">
+        <h1>Slideshow</h1>
+      </div>
+    </div>
+  </template>
+  
+  <script src="./index.js"></script>
+  <script>
+    const app = document.getElementById("app");
+    const slideshow = new SlideShow();
+    slideshow.mount(app);
+  </script>
+
+  <p>Lorem ipsum...</p>
+</body>
+</html>

--- a/examples/slideshow/index.js
+++ b/examples/slideshow/index.js
@@ -11,16 +11,16 @@ class SlideShow extends Template {
     this.wide = [];
     this.tall = [];
     this.images = [
-      "./images/1.jpg",
-      "./images/2.jpg",
-      "./images/3.jpg",
-      "./images/4.jpg",
-      "./images/5.jpg",
-      "./images/6.jpg",
-      "./images/7.jpg",
-      "./images/8.jpg",
-      "./images/9.jpg",
-      "./images/10.jpg",
+      "https://placehold.co/800x600",
+      "https://picsum.photos/800/600",
+      "https://loremflickr.com/800/600",
+      "https://placekitten.com/800/600",
+      "https://loremflickr.com/800/600",
+      "https://picsum.photos/1024/800",
+      "https://placehold.co/1024x800",
+      "https://placekitten.com/1024/800",
+      "https://loremflickr.com/1200/1024",
+      "https://picsum.photos/1200/1024",
     ];
     this.render();
   }

--- a/examples/slideshow/slideshow.css
+++ b/examples/slideshow/slideshow.css
@@ -1,0 +1,115 @@
+
+.slide-show {
+  width: 100vw;
+  height: 100vh;
+  max-height: -webkit-fill-available;
+  overflow: hidden;
+}
+.slide-show h1 {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: white;
+  float: left;
+  margin: 60px;
+  z-index: 1;
+}
+.slide-show .preview {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+  position: relative;
+}
+.slide-show .preview .background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  flex-grow: 1;
+  background-size: cover;
+  background-position: center;
+  animation-name: slide-show-image;
+  animation-duration: 6s;
+  animation-timing-function: linear;
+  overflow: hidden;
+}
+@keyframes slide-show-image-0 {
+  0% {
+    transform: scale(1, 1) translate(0, 0);
+    opacity: 100%;
+  }
+  80% {
+    opacity: 100%;
+  }
+  100% {
+    transform: scale(115%, 115%) translate(5%, 5%);
+    opacity: 0%;
+  }
+}
+@keyframes slide-show-image-1 {
+  0% {
+    transform: scale(1, 1) translate(0, 0);
+    opacity: 100%;
+  }
+  80% {
+    opacity: 100%;
+  }
+  100% {
+    transform: scale(115%, 115%) translate(1%, 5%);
+    opacity: 0%;
+  }
+}
+@keyframes slide-show-image-2 {
+  0% {
+    transform: scale(1, 1) translate(0, 0);
+    opacity: 100%;
+  }
+  80% {
+    opacity: 100%;
+  }
+  100% {
+    transform: scale(115%, 115%) translate(-5%, 5%);
+    opacity: 0%;
+  }
+}
+@keyframes slide-show-image-3 {
+  0% {
+    transform: scale(1, 1) translate(0, 0);
+    opacity: 100%;
+  }
+  80% {
+    opacity: 100%;
+  }
+  100% {
+    transform: scale(115%, 115%) translate(-1%, 5%);
+    opacity: 0%;
+  }
+}
+@keyframes slide-show-image-4 {
+  0% {
+    transform: scale(1, 1) translate(0, 0);
+    opacity: 100%;
+  }
+  80% {
+    opacity: 100%;
+  }
+  100% {
+    transform: scale(115%, 115%) translate(-5%, -5%);
+    opacity: 0%;
+  }
+}
+@keyframes slide-show-image-5 {
+  0% {
+    transform: scale(1, 1) translate(0, 0);
+    opacity: 100%;
+  }
+  80% {
+    opacity: 100%;
+  }
+  100% {
+    transform: scale(115%, 115%) translate(5%, -5%);
+    opacity: 0%;
+  }
+}


### PR DESCRIPTION
This change/addition to the slideshow demo would make it work right away upon double-clicking the index.html.

I for instance had overlooked the hint in the main Readme that the CSS styles (here especially the animation directives) have to go inside the template to affect the template's shadow-root. I'm assuming providing a 'ready-to-go' demo like this would make the whole thing easier for people yet unfamiliar with Shadow DOM.